### PR TITLE
fix(frontend): ローカル投稿者のノートでリアクション絵文字をインポートできない問題の修正

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -92,7 +92,7 @@ const router = useRouter();
 
 const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
 
-const canSteal = computed(() => props.note.user.host && $i && ($i.isAdmin || $i.policies.canManageCustomEmojis));
+const canSteal = computed(() => $i != null && ($i.isAdmin || $i.policies.canManageCustomEmojis));
 
 const longTouchEmoji = ref(false);
 
@@ -225,7 +225,7 @@ function stealReaction(ev: MouseEvent) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value !== '.') {
+	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',
@@ -321,7 +321,7 @@ async function menu(ev) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value !== '.') {
+	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',


### PR DESCRIPTION
## 概要

ローカルユーザーが投稿したノートに付いたリモート絵文字のリアクションから、絵文字のインポートメニューが表示されない問題を修正します。

## 背景・原因

upstream(yojo-art)への追従により、インポートボタンの表示条件が以下に変わっていました。

```js
const canSteal = computed(() => props.note.user.host && $i && ($i.isAdmin || $i.policies.canManageCustomEmojis));
```

`props.note.user.host`(=ノート投稿者がリモートユーザー)が必須のため、投稿者がローカルだと管理者・絵文字管理権限者であってもインポート項目が表示されませんでした。本来インポート可否はリアクション絵文字自体のホストで判定すべきです。

## 主な変更点

- `canSteal` をノート投稿者ホスト依存から外し、権限のみで判定するよう変更
- `stealReaction` / `menu` の2箇所の表示ガードを `canSteal.value && reactionHost.value && reactionHost.value !== '.'` に変更
  - リモート絵文字(`:foo@example.com:`)なら投稿者を問わずインポート可
  - ローカル絵文字(`@.`)・Unicode絵文字・ホスト無しは対象外(`admin/emoji/steal` へ host 未指定で投げる事故を防止)

## 注意点

- これはupstream(yojo-art)の仕様からの意図的な差分(自フォーク独自挙動)です。今後の追従時にコンフリクトし得る点に留意してください。

## テスト

- フロントエンドをビルドし、ローカルユーザーのノートに付いたリモート絵文字リアクションを左クリック/右クリックして、インポート項目が表示されることを手動確認
- ローカル絵文字・Unicode絵文字のリアクションでインポート項目が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)