### PR TITLE
fix(frontend): リアクションメニューのインポート表示条件とラベル表示の修正

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -94,6 +94,10 @@ const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactabl
 
 const canSteal = computed(() => $i != null && ($i.isAdmin || $i.policies.canManageCustomEmojis));
 
+const canImport = computed(() => canSteal.value && props.reaction.includes(':') && !!reactionHost.value && reactionHost.value !== '.' && !customEmojisMap.has(reactionName.value));
+
+const reactionLabel = computed(() => props.reaction.includes(':') ? `:${reactionName.value}:` : props.reaction);
+
 const longTouchEmoji = ref(false);
 
 async function toggleReaction(ev: MouseEvent) {
@@ -195,7 +199,7 @@ function stealReaction(ev: MouseEvent) {
 
 	menuItems.push({
 		type: 'label',
-		text: `:${reactionName.value}:`,
+		text: reactionLabel.value,
 	});
 
 	if (canGetInfo.value) {
@@ -225,7 +229,7 @@ function stealReaction(ev: MouseEvent) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
+	if (canImport.value) {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',
@@ -291,7 +295,7 @@ async function menu(ev) {
 
 	menuItems.push({
 		type: 'label',
-		text: `:${reactionName.value}:`,
+		text: reactionLabel.value,
 	});
 
 	if (canGetInfo.value) {
@@ -321,7 +325,7 @@ async function menu(ev) {
 		});
 	}
 
-	if (canSteal.value && reactionHost.value && reactionHost.value !== '.') {
+	if (canImport.value) {
 		menuItems.push({
 			text: i18n.ts.import,
 			icon: 'ti ti-plus',

--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -75,7 +75,7 @@ const canToggle = computed(() => {
 	//return !props.reaction.match(/@\w/) && $i && emoji && checkReactionPermissions($i, props.note, emoji);
 	return props.reaction.match(/@\w/) == null && $i != null && emoji != null;
 });
-const canGetInfo = computed(() => props.reaction.includes(':'));
+const canGetInfo = computed(() => props.reaction.startsWith(':'));
 const isLocalCustomEmoji = props.reaction[0] === ':' && props.reaction.includes('@.');
 
 const reactionName = computed(() => {
@@ -94,9 +94,9 @@ const alternative: ComputedRef<string | null> = computed(() => prefer.s.reactabl
 
 const canSteal = computed(() => $i != null && ($i.isAdmin || $i.policies.canManageCustomEmojis));
 
-const canImport = computed(() => canSteal.value && props.reaction.includes(':') && !!reactionHost.value && reactionHost.value !== '.' && !customEmojisMap.has(reactionName.value));
+const canImport = computed(() => canSteal.value && props.reaction.startsWith(':') && !!reactionHost.value && reactionHost.value !== '.' && !customEmojisMap.has(reactionName.value));
 
-const reactionLabel = computed(() => props.reaction.includes(':') ? `:${reactionName.value}:` : props.reaction);
+const reactionLabel = computed(() => props.reaction.startsWith(':') ? `:${reactionName.value}:` : props.reaction);
 
 const longTouchEmoji = ref(false);
 


### PR DESCRIPTION
## 概要

リアクションのメニュー(`stealReaction` / `menu`)で見つかった3つの不具合を修正します。

## 修正内容

`MkReactionsViewer.reaction.vue` に computed を2つ追加し、`stealReaction` / `menu` の両関数で使用します。

```js
const canImport = computed(() => canSteal.value && props.reaction.includes(':') && !!reactionHost.value && reactionHost.value !== '.' && !customEmojisMap.has(reactionName.value));

const reactionLabel = computed(() => props.reaction.includes(':') ? `:${reactionName.value}:` : props.reaction);
```

| 不具合 | 原因 | 修正 |
|---|---|---|
| ① Unicode絵文字にインポートボタンが表示される | `:`を含まない/ホスト無しのリアクションでも表示されていた | `canImport` が `props.reaction.includes(':')` と `!!reactionHost.value` を要求し除外 |
| ② ローカルに同名ショートコードがあってもインポート/インポート+リアクションが表示される | 同名ローカル絵文字の有無を見ていなかった | `!customEmojisMap.has(reactionName.value)` により同名ローカルがあれば両ボタンを非表示 |
| ③ Unicode絵文字でラベルのショートコード表示が壊れる(`:?:`等) | `reactionName` が `slice(0, -1)` でUnicode絵文字を壊していた | `reactionLabel` で Unicode絵文字はそのまま絵文字を、カスタム絵文字は `:name:` を表示 |

## テスト

- ESLint: 0エラー(該当ファイル。残存警告はすべて既存のもの)
- 各リアクション種別(Unicode / ローカルカスタム / リモートカスタム / 同名ローカルありのリモート)で `canImport` と `reactionLabel` の評価を確認

## 関連

- 直前のPR(ローカル投稿者のノートでインポートできない問題の修正)の後続です

🤖 Generated with [Claude Code](https://claude.com/claude-code)