### PR TITLE
enhance(frontend): 公開範囲に応じてノートカードの背景を色付けする機能を追加

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -508,16 +508,17 @@ const { $note: $appearNote, subscribe: subscribeManuallyToNoteCapture } = useNot
 });
 
 // 公開範囲に応じてノートカードの背景を着色する。色相はユーザー設定のhexを用い、
-// 透明度は約10%(hex末尾の1a)固定で重ねることで旧カスタムCSSのrgba(...,0.10)を再現する
+// 透明度は約10%(hex末尾の1a)固定で重ねることで旧カスタムCSSのrgba(...,0.10)を再現する。
+// publicは対象外(対応キーなし)
+const visibilityColorKeys: Partial<Record<typeof appearNote.visibility, 'visibilityColorHome' | 'visibilityColorFollowers' | 'visibilityColorSpecified'>> = {
+	home: 'visibilityColorHome',
+	followers: 'visibilityColorFollowers',
+	specified: 'visibilityColorSpecified',
+};
 const visibilityBgStyle = computed(() => {
 	if (!store.s.coloredNoteByVisibility) return {};
-	const colorMap: Partial<Record<typeof appearNote.visibility, string>> = {
-		home: store.s.visibilityColorHome,
-		followers: store.s.visibilityColorFollowers,
-		specified: store.s.visibilityColorSpecified,
-	};
-	const hex = colorMap[appearNote.visibility];
-	return hex ? { backgroundColor: `${hex}1a` } : {};
+	const key = visibilityColorKeys[appearNote.visibility];
+	return key ? { backgroundColor: `${store.s[key]}1a` } : {};
 });
 
 const enableAnimatedMfm = $i ? true : computed(store.makeGetterSetter('animatedMfm'));

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	ref="rootEl"
 	v-hotkey="keymap"
 	:class="[$style.root, { [$style.showActionsOnlyHover]: prefer.s.showNoteActionsOnlyHover, [$style.skipRender]: prefer.s.skipNoteRender }]"
+	:style="visibilityBgStyle"
 	tabindex="0"
 >
 	<div v-if="pinned" :class="$style.tip"><i class="ti ti-pin"></i> {{ i18n.ts.pinnedNote }}</div>
@@ -504,6 +505,19 @@ const { $note: $appearNote, subscribe: subscribeManuallyToNoteCapture } = useNot
 	note: appearNote,
 	parentNote: note,
 	mock: props.mock,
+});
+
+// 公開範囲に応じてノートカードの背景を着色する。色相はユーザー設定のhexを用い、
+// 透明度は約10%(hex末尾の1a)固定で重ねることで旧カスタムCSSのrgba(...,0.10)を再現する
+const visibilityBgStyle = computed(() => {
+	if (!store.s.coloredNoteByVisibility) return {};
+	const colorMap: Partial<Record<typeof appearNote.visibility, string>> = {
+		home: store.s.visibilityColorHome,
+		followers: store.s.visibilityColorFollowers,
+		specified: store.s.visibilityColorSpecified,
+	};
+	const hex = colorMap[appearNote.visibility];
+	return hex ? { backgroundColor: `${hex}1a` } : {};
 });
 
 const enableAnimatedMfm = $i ? true : computed(store.makeGetterSetter('animatedMfm'));

--- a/packages/frontend/src/pages/settings/shiroha.vue
+++ b/packages/frontend/src/pages/settings/shiroha.vue
@@ -26,6 +26,25 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<template #label><SearchLabel>ファイル添付ボタンをメニューにまとめる</SearchLabel> <span class="_beta">Shiroha</span></template>
 					</MkSwitch>
 				</SearchMarker>
+
+				<SearchMarker :keywords="['note', 'visibility', 'color', 'background']">
+					<MkSwitch v-model="coloredNoteByVisibility">
+						<template #label><SearchLabel>公開範囲に応じてノートの背景を色付け</SearchLabel> <span class="_beta">Shiroha</span></template>
+						<template #caption><SearchText>ホーム・フォロワー・ダイレクトの投稿を、設定した色で薄く着色します。</SearchText></template>
+					</MkSwitch>
+				</SearchMarker>
+
+				<template v-if="coloredNoteByVisibility">
+					<MkColorInput v-model="visibilityColorHome">
+						<template #label>ホーム</template>
+					</MkColorInput>
+					<MkColorInput v-model="visibilityColorFollowers">
+						<template #label>フォロワー</template>
+					</MkColorInput>
+					<MkColorInput v-model="visibilityColorSpecified">
+						<template #label>ダイレクト</template>
+					</MkColorInput>
+				</template>
 			</div>
 		</FormSection>
 	</div>
@@ -35,6 +54,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script lang="ts" setup>
 import { computed, watch } from 'vue';
 import MkSwitch from '@/components/MkSwitch.vue';
+import MkColorInput from '@/components/MkColorInput.vue';
 import FormSection from '@/components/form/section.vue';
 import { store } from '@/store.js';
 import { globalEvents } from '@/events.js';
@@ -44,6 +64,10 @@ import { suggestReload } from '@/utility/reload-suggest.js';
 const useSearchConversionSyntax = computed(store.makeGetterSetter('useSearchConversionSyntax'));
 const useClassicPostForm = computed(store.makeGetterSetter('useClassicPostForm'));
 const useClassicFileAttachMenu = computed(store.makeGetterSetter('useClassicFileAttachMenu'));
+const coloredNoteByVisibility = computed(store.makeGetterSetter('coloredNoteByVisibility'));
+const visibilityColorHome = computed(store.makeGetterSetter('visibilityColorHome'));
+const visibilityColorFollowers = computed(store.makeGetterSetter('visibilityColorFollowers'));
+const visibilityColorSpecified = computed(store.makeGetterSetter('visibilityColorSpecified'));
 
 // 投稿フォームの仕様変更は再読み込みが必要なためリロードを促す
 watch(useClassicPostForm, () => {

--- a/packages/frontend/src/pages/settings/shiroha.vue
+++ b/packages/frontend/src/pages/settings/shiroha.vue
@@ -35,15 +35,21 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</SearchMarker>
 
 				<template v-if="coloredNoteByVisibility">
-					<MkColorInput v-model="visibilityColorHome">
-						<template #label>ホーム</template>
-					</MkColorInput>
-					<MkColorInput v-model="visibilityColorFollowers">
-						<template #label>フォロワー</template>
-					</MkColorInput>
-					<MkColorInput v-model="visibilityColorSpecified">
-						<template #label>ダイレクト</template>
-					</MkColorInput>
+					<div :class="$style.colorRow" :style="{ backgroundColor: `${visibilityColorHome}1a` }">
+						<MkColorInput v-model="visibilityColorHome">
+							<template #label>ホーム</template>
+						</MkColorInput>
+					</div>
+					<div :class="$style.colorRow" :style="{ backgroundColor: `${visibilityColorFollowers}1a` }">
+						<MkColorInput v-model="visibilityColorFollowers">
+							<template #label>フォロワー</template>
+						</MkColorInput>
+					</div>
+					<div :class="$style.colorRow" :style="{ backgroundColor: `${visibilityColorSpecified}1a` }">
+						<MkColorInput v-model="visibilityColorSpecified">
+							<template #label>ダイレクト</template>
+						</MkColorInput>
+					</div>
 				</template>
 			</div>
 		</FormSection>
@@ -88,3 +94,12 @@ definePage(() => ({
 	icon: 'ti ti-settings',
 }));
 </script>
+
+<style lang="scss" module>
+.colorRow {
+	padding: 12px;
+	border-radius: var(--MI-radius);
+	// 実際にノートへ適用される透明度(約10%)の見え方をプレビューする
+	transition: background-color 0.2s;
+}
+</style>

--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -871,6 +871,22 @@ export const store = markRaw(new Pizzax('base', {
 		where: 'device',
 		default: false,
 	},
+	coloredNoteByVisibility: {
+		where: 'device',
+		default: false,
+	},
+	visibilityColorHome: {
+		where: 'device',
+		default: '#00ffff',
+	},
+	visibilityColorFollowers: {
+		where: 'device',
+		default: '#ff00ff',
+	},
+	visibilityColorSpecified: {
+		where: 'device',
+		default: '#ffff64', // rgb(255, 255, 100)
+	},
 	// #endregion
 }));
 


### PR DESCRIPTION
## 概要

タイムラインのノートカードを、投稿の公開範囲(visibility)に応じて背景色で塗り分ける機能を追加します。

以前は他者作のカスタムCSS(`.xcSej:has(.ti-home)`等)でアイコン存在を`:has()`判定して着色していましたが、Misskey/Cherrypickのバージョンアップでscoped CSSのハッシュクラス名・DOM構造が変わり機能しなくなりました。本PRではハッシュ依存をやめ、`appearNote.visibility`を直接参照する正規実装に置き換えます。

## 主な変更

- **`store.ts`**: Shirohaセクションに設定4項目を追加(`where: 'device'`)
  - `coloredNoteByVisibility`(トグル、デフォルト`false`)
  - `visibilityColorHome` = `#00ffff` / `visibilityColorFollowers` = `#ff00ff` / `visibilityColorSpecified` = `#ffff64`
- **`MkNote.vue`**: `appearNote.visibility`を参照する`visibilityBgStyle` computedを追加し、ルートdivに`:style`で適用
- **`shiroha.vue`**: トグル＋`MkColorInput`3つ(トグルON時のみ表示)を追加

## 設計上の注意点

- 再現対象の旧CSS配色: home=`rgba(0,255,255,0.10)` / followers=`rgba(255,0,255,0.10)` / specified=`rgba(255,255,100,0.10)`。publicは着色対象外。
- `MkColorInput`は`<input type="color">`でhex(6桁)のみ扱い透明度を持てないため、**色相はユーザーがhexで選択／透明度は約10%固定**(hex末尾`1a`の8桁hex)で背景に重ねる方式とした。これにより元CSSの`rgba(..., 0.10)`を再現しつつ色のカスタマイズも可能。
- `store.s`はリアクティブなため、設定変更はタイムラインに即時反映される(リロード不要)。
- `MkNoteSub`/`MkNoteSimple`はvisibility非参照のため対象外。
- デフォルトは無効のため、既存ユーザーの見た目に影響なし。

## テスト

- `npx eslint`(対象3ファイル): **0 errors**(既存warningのみ、追加コードには発生なし)
- 実機での動作確認手順:
  1. 設定 → Shiroha にトグル/色入力が表示されること
  2. トグルOFF(デフォルト)でノート背景に変化がないこと
  3. トグルONでhome/followers/specifiedが各色で薄く着色、publicは無着色であること
  4. 色入力の変更が対応する公開範囲のノートに即時反映されること
  5. hover時の既存ハイライトが壊れないこと

## 関連

- 設定追加先: フォーク独自の「Shiroha」設定メニュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)
